### PR TITLE
Add dumb-init to base development node image

### DIFF
--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -1,0 +1,4 @@
+FROM node
+RUN apt-get update
+RUN apt-get install -y dumb-init
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]


### PR DESCRIPTION
This adds dumb-init so we probably handle the SIGINT for interactive development with docker-compose.
Now when we do ctrl-c the docker container won't stick around.